### PR TITLE
Cats Effect 3 Upgrade

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: install sbt
       run: |
-        echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+        echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+        echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
         sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
         sudo apt-get update
         sudo apt-get install sbt

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-enablePlugins(MicrositesPlugin)
-enablePlugins(TutPlugin)
+//enablePlugins(MicrositesPlugin)
+//enablePlugins(TutPlugin)
 
 organization := "net.andimiller"
 
@@ -16,8 +16,8 @@ def enablePartialUnification(version: String) = version match {
 
 scalacOptions ++= enablePartialUnification(scalaBinaryVersion.value)
 
-lazy val catsEffectVersion    = "2.0.0-M4"
-lazy val fs2Version           = "1.1.0-M1"
+lazy val catsEffectVersion    = "3.3.14"
+lazy val fs2Version           = "3.2.14"
 lazy val spotifyDockerVersion = "8.14.4"
 
 libraryDependencies ++= Seq(
@@ -40,46 +40,46 @@ libraryDependencies ++= Seq(
   "com.ovoenergy"  %% "fs2-kafka"           % "0.20.0-M1"   % Test,
 )
 
-libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-blaze-client" % http4sVersion % Tut,
-)
+//libraryDependencies ++= Seq(
+//  "org.http4s" %% "http4s-blaze-client" % http4sVersion % Tut,
+//)
 
 scalafmtConfig in ThisBuild := Some(file("scalafmt.conf"))
 
 // Microsite things
-
-micrositeName := "whales"
-
-micrositeDescription := "Cats-based Docker Client"
-
-micrositeAuthor := "Andi Miller"
-
-micrositeOrganizationHomepage := "http://andimiller.net/"
-
-micrositeGithubOwner := "andimiller"
-micrositeGithubRepo := "whales"
-
-micrositeUrl := "https://whales.andimiller.net"
-
-micrositeHomepage := "https://whales.andimiller.net"
-
-micrositeDocumentationUrl := "/getting-started.html"
-
-micrositePalette := Map(
-  "brand-primary"   -> "#80CBC4",
-  "brand-secondary" -> "#00796B",
-  "brand-tertiary"  -> "#004D40",
-  "gray-dark"       -> "#453E46",
-  "gray"            -> "#837F84",
-  "gray-light"      -> "#E3E2E3",
-  "gray-lighter"    -> "#F4F3F4",
-  "white-color"     -> "#FFFFFF"
-)
-
-excludeFilter in ghpagesCleanSite :=
-  new FileFilter {
-    def accept(f: File) = (ghpagesRepository.value / "CNAME").getCanonicalPath == f.getCanonicalPath
-  }
+//
+//micrositeName := "whales"
+//
+//micrositeDescription := "Cats-based Docker Client"
+//
+//micrositeAuthor := "Andi Miller"
+//
+//micrositeOrganizationHomepage := "http://andimiller.net/"
+//
+//micrositeGithubOwner := "andimiller"
+//micrositeGithubRepo := "whales"
+//
+//micrositeUrl := "https://whales.andimiller.net"
+//
+//micrositeHomepage := "https://whales.andimiller.net"
+//
+//micrositeDocumentationUrl := "/getting-started.html"
+//
+//micrositePalette := Map(
+//  "brand-primary"   -> "#80CBC4",
+//  "brand-secondary" -> "#00796B",
+//  "brand-tertiary"  -> "#004D40",
+//  "gray-dark"       -> "#453E46",
+//  "gray"            -> "#837F84",
+//  "gray-light"      -> "#E3E2E3",
+//  "gray-lighter"    -> "#F4F3F4",
+//  "white-color"     -> "#FFFFFF"
+//)
+//
+//excludeFilter in ghpagesCleanSite :=
+//  new FileFilter {
+//    def accept(f: File) = (ghpagesRepository.value / "CNAME").getCanonicalPath == f.getCanonicalPath
+//  }
 
 // publishing/releasing settings
 import xerial.sbt.Sonatype._

--- a/build.sbt
+++ b/build.sbt
@@ -14,10 +14,14 @@ def enablePartialUnification(version: String) = version match {
   case "2.13"          => List.empty
 }
 
+scalacOptions ++= Seq(
+  "-language:higherKinds",
+)
+
 scalacOptions ++= enablePartialUnification(scalaBinaryVersion.value)
 
 lazy val catsEffectVersion    = "3.3.14"
-lazy val fs2Version           = "3.2.14"
+lazy val fs2Version           = "3.4.0"
 lazy val spotifyDockerVersion = "8.14.4"
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.spotify"   % "docker-client" % spotifyDockerVersion,
 )
 
-lazy val http4sVersion = "0.21.0-M1"
+lazy val http4sVersion = "0.23.11"
 
 libraryDependencies ++= Seq(
   "org.scalatest"  %% "scalatest"           % "3.0.8"       % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -31,17 +31,17 @@ libraryDependencies ++= Seq(
   "com.spotify"   % "docker-client" % spotifyDockerVersion,
 )
 
-lazy val http4sVersion = "0.23.11"
+lazy val  http4sVersion = "0.23.11"
 
 libraryDependencies ++= Seq(
-  "org.scalatest"  %% "scalatest"           % "3.0.8"       % Test,
-  "org.http4s"     %% "http4s-blaze-client" % http4sVersion % Test,
-  "org.http4s"     %% "http4s-blaze-server" % http4sVersion % Test,
-  "org.http4s"     %% "http4s-dsl"          % http4sVersion % Test,
-  "ch.qos.logback" % "logback-classic"      % "1.2.3"       % Test,
-  "org.tpolecat"   %% "doobie-core"         % "0.8.0-M1"    % Test,
-  "mysql"          % "mysql-connector-java" % "8.0.15"      % Test,
-  "com.ovoenergy"  %% "fs2-kafka"           % "0.20.0-M1"   % Test,
+  "org.scalatest"   %% "scalatest"           % "3.0.8"       % Test,
+  "org.http4s"      %% "http4s-blaze-client" % http4sVersion % Test,
+  "org.http4s"      %% "http4s-blaze-server" % http4sVersion % Test,
+  "org.http4s"      %% "http4s-dsl"          % http4sVersion % Test,
+  "ch.qos.logback"  %  "logback-classic"     % "1.2.3"       % Test,
+  "org.tpolecat"    %% "doobie-core"         % "1.0.0-RC2"   % Test,
+  "mysql"           % "mysql-connector-java" % "8.0.15"      % Test,
+  "com.github.fd4s" %% "fs2-kafka"           % "3.0.0-M9"    % Test,
 )
 
 //libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.8
+sbt.version = 1.5.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.47deg"         % "sbt-microsites" % "0.7.27")
-addSbtPlugin("org.tpolecat"      % "tut-plugin"     % "0.6.12")
+//addSbtPlugin("org.tpolecat"      % "tut-plugin"     % "0.6.12")
 addSbtPlugin("com.github.gseitz" % "sbt-release"    % "1.0.10")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"   % "2.4")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"        % "1.1.0")

--- a/src/main/scala/net/andimiller/whales/aquarium/Kafka.scala
+++ b/src/main/scala/net/andimiller/whales/aquarium/Kafka.scala
@@ -1,15 +1,15 @@
 package net.andimiller.whales.aquarium
 
 import cats._
+import cats.effect.{Resource, Temporal}
 import cats.implicits._
-import cats.effect._
 import net.andimiller.whales._
 import net.andimiller.whales.syntax._
 
 import scala.concurrent.duration._
 
 object Kafka {
-  def singleNode[F[_]: Effect: Timer](topics: List[String]): Resource[F, DockerContainer] =
+  def singleNode[F[_]: Temporal](topics: List[String]): Resource[F, DockerContainer] =
     for {
       docker <- Docker[F]
       zookeeper <- docker(

--- a/src/main/scala/net/andimiller/whales/aquarium/Kafka.scala
+++ b/src/main/scala/net/andimiller/whales/aquarium/Kafka.scala
@@ -19,7 +19,7 @@ object Kafka {
                   )
       _ <- zookeeper.waitForPort[F](2181, delay = 100.millis, backoffs = 10)
       kafka <- docker(
-                "andimiller/kafka",
+                "confluentinc/cp-kafka",
                 "latest",
                 name = "kafka".some,
                 bindings = Map(9092.tcp -> Binding(port = Option(9092))),

--- a/src/main/scala/net/andimiller/whales/aquarium/Kafka.scala
+++ b/src/main/scala/net/andimiller/whales/aquarium/Kafka.scala
@@ -1,7 +1,7 @@
 package net.andimiller.whales.aquarium
 
 import cats._
-import cats.effect.{Resource, Temporal}
+import cats.effect.{Async, Resource, Sync, Temporal}
 import cats.implicits._
 import net.andimiller.whales._
 import net.andimiller.whales.syntax._
@@ -9,7 +9,7 @@ import net.andimiller.whales.syntax._
 import scala.concurrent.duration._
 
 object Kafka {
-  def singleNode[F[_]: Temporal](topics: List[String]): Resource[F, DockerContainer] =
+  def singleNode[F[_]: Async: Sync: Temporal](topics: List[String]): Resource[F, DockerContainer] =
     for {
       docker <- Docker[F]
       zookeeper <- docker(

--- a/src/main/scala/net/andimiller/whales/aquarium/MySQL.scala
+++ b/src/main/scala/net/andimiller/whales/aquarium/MySQL.scala
@@ -32,7 +32,7 @@ object MySQL {
     def withBindToHost: MySQLConfiguration                     = copy(bindToHost = true)
   }
 
-  def v8[F[_]: Temporal](config: MySQLConfiguration): Resource[F, DockerContainer] =
+  def v8[F[_]: Async: Temporal](config: MySQLConfiguration): Resource[F, DockerContainer] =
     for {
       docker <- Docker[F]
       extraEnv = List(

--- a/src/main/scala/net/andimiller/whales/aquarium/MySQL.scala
+++ b/src/main/scala/net/andimiller/whales/aquarium/MySQL.scala
@@ -32,7 +32,7 @@ object MySQL {
     def withBindToHost: MySQLConfiguration                     = copy(bindToHost = true)
   }
 
-  def v8[F[_]: Effect: Timer](config: MySQLConfiguration): Resource[F, DockerContainer] =
+  def v8[F[_]: Temporal](config: MySQLConfiguration): Resource[F, DockerContainer] =
     for {
       docker <- Docker[F]
       extraEnv = List(

--- a/src/main/scala/net/andimiller/whales/package.scala
+++ b/src/main/scala/net/andimiller/whales/package.scala
@@ -106,7 +106,7 @@ package object whales {
                                                     delay: FiniteDuration = 1.second): F[ExitedContainer] =
       Stream
         .retry(
-          Sync[F].delay {
+          Sync[F].interruptible {
             val state = docker.inspectContainer(id).state()
             assert(state.running() == false, s"Container $id still running")
             ExitedContainer(state.exitCode(), docker.logs(id, LogsParam.stdout(), LogsParam.stderr()).readFully())
@@ -125,7 +125,7 @@ package object whales {
                                                    delay: FiniteDuration = 1.second,
                                                    nextDelay: FiniteDuration => FiniteDuration): F[Unit] =
       Stream
-        .retry(Sync[F].delay {
+        .retry(Sync[F].interruptible {
           new Socket(host, port)
         }, delay = delay, nextDelay = nextDelay, maxAttempts = backoffs)
         .compile

--- a/src/test/scala/DockerSpec.scala
+++ b/src/test/scala/DockerSpec.scala
@@ -1,15 +1,10 @@
 import java.io.File
 import java.util.concurrent.{Executor, ExecutorService, Executors}
-
 import org.http4s._
 import org.http4s.implicits._
 import org.http4s.dsl.io._
-import cats._
-import cats.implicits._
-import cats.data._
 import cats.effect._
-import cats.effect.implicits._
-import cats.effect.internals.IOContextShift
+import cats.effect.unsafe.IORuntime
 import net.andimiller.whales._
 import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.util.CaseInsensitiveString
@@ -30,10 +25,7 @@ class DockerSpec extends FlatSpec with MustMatchers {
     })
 
   implicit val is = Sync[IO]
-
-  implicit val cs    = IO.contextShift(ExecutionContext.global)
-  implicit val ce    = ConcurrentEffect[IO]
-  implicit val timer = IO.timer(ExecutionContext.global)
+  implicit val runtime = IORuntime.builder().build()
 
   "Docker" must "successfully spin up nginx" in {
     val resources = for {

--- a/src/test/scala/MysqlSpec.scala
+++ b/src/test/scala/MysqlSpec.scala
@@ -1,7 +1,7 @@
 import java.io.File
 import java.nio.file.Path
-
 import cats._
+import cats.effect.unsafe.IORuntime
 import implicits._
 import effect._
 import doobie._
@@ -15,8 +15,7 @@ import scala.concurrent.ExecutionContext.global
 
 class MysqlSpec extends FlatSpec with MustMatchers {
 
-  implicit val timer = IO.timer(global)
-  implicit val cs    = IO.contextShift(global)
+  implicit val runtime = IORuntime.builder().build()
 
   case class Cat(name: String, age: Int)
   def insertCat(c: Cat) = sql"insert into cat values(${c.name}, ${c.age})".update.run


### PR DESCRIPTION
This PR updates the library to use Cats Effect 3. This required updating `sbt` and commenting out dependancies that were unhappy (tut e.g.). ATM the tests do hang locally as there seems to be an issue with the underlying docker lib getting kafka spun up. However everything compiles and other test resources are healthy.